### PR TITLE
Propose a mechanism to auto-remove temp files on response close/finish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+.idea
 /node_modules

--- a/README.md
+++ b/README.md
@@ -3,9 +3,6 @@
 [connect](https://github.com/senchalabs/connect/) middleware for
 [multiparty](https://github.com/andrewrk/node-multiparty/).
 
-~I actually recommend against using this module. It's cleaner to use the
-multiparty API directly.~
-
 You should not add this middleware to all routes; only to the ones
 in which you want to accept uploads. 
 
@@ -22,10 +19,9 @@ automatic temp files cleaning with something like [reap](https://github.com/visi
 
 ```js
 var multipart = require('connect-multiparty');
-var multipartMiddleware = multipart();
+var multipartMiddleware = multipart({}, true);
 app.post('/upload', multipartMiddleware, function(req, resp) {
   console.log(req.body, req.files);
-  // don't forget to delete all req.files when done
 });
 ```
 ## Options

--- a/README.md
+++ b/README.md
@@ -28,12 +28,12 @@ app.post('/upload', multipartMiddleware, function(req, resp) {
   // don't forget to delete all req.files when done
 });
 ```
-
-```multipart()``` options are:
+## Options
 
 ```js
 multipart(options, autoClean)
 ```
 
-```options``` object is passed directly into multiparty.
-```autoClean``` will remove all temp files on request finishing
+* ```options``` object is passed directly into multiparty.
+
+* ```autoClean``` set to true to remove all temp files on request finishing.

--- a/README.md
+++ b/README.md
@@ -3,13 +3,20 @@
 [connect](https://github.com/senchalabs/connect/) middleware for
 [multiparty](https://github.com/andrewrk/node-multiparty/).
 
-I actually recommend against using this module. It's cleaner to use the
-multiparty API directly.
+~I actually recommend against using this module. It's cleaner to use the
+multiparty API directly.~
 
-This middleware will create temp files on your server and never clean them
-up. Thus you should not add this middleware to all routes; only to the ones
-in which you want to accept uploads. And in these endpoints, be sure to
-delete all temp files, even the ones that you don't use.
+You should not add this middleware to all routes; only to the ones
+in which you want to accept uploads. 
+
+This middleware will create temp files on your server.
+If you set autoClean to true temp files are  automatically removed at the
+end request (on res 'finish' event).
+If you *not* set autoClean, be sure to delete all temp files, even the ones
+that you don't use (multiparty create file even for empty inputs file).
+
+node.js could crash before end of request. This is why you *SHOULD* implement
+automatic temp files cleaning with something like [reap](https://github.com/visionmedia/reap) for example.
 
 ## Usage
 
@@ -22,5 +29,11 @@ app.post('/upload', multipartMiddleware, function(req, resp) {
 });
 ```
 
-If you pass options to `multipart()`, they are passed directly into
-multiparty.
+```multipart()``` options are:
+
+```js
+multipart(options, autoClean)
+```
+
+```options``` object is passed directly into multiparty.
+```autoClean``` will remove all temp files on request finishing

--- a/examples/index.js
+++ b/examples/index.js
@@ -1,0 +1,51 @@
+/**
+ * Module dependencies.
+ */
+
+var express = require('express');
+var bodyParser = require('body-parser');
+var multipart = require('./../index');
+var multipartMiddleware = multipart({}, true);
+var format = require('util').format;
+
+var app = module.exports = express();
+
+app.use(bodyParser());
+
+app.get('/', function (req, res) {
+  res.send('<form method="post" enctype="multipart/form-data">'
+    + '<h1>Multipart form</h1>'
+    + '<p>Title: <input type="text" name="title" /></p>'
+    + '<p>Image: <input type="file" name="image" /></p>'
+    + '<p><input type="submit" value="Upload" /></p>'
+    + '</form>'
+    + '<form method="post">'
+    + '<h1>No multipart form</h1>'
+    + '<p>Title: <input type="text" name="title" /></p>'
+    + '<p><input type="submit" value="Post" /></p>'
+    + '</form>');
+});
+
+app.post('/', multipartMiddleware, function (req, res, next) {
+  // the uploaded file can be found as `req.files.image` and the
+  // title field as `req.body.title`
+  if (req.files && req.files.image) {
+    res.send(format('\nuploaded file <strong>%s</strong> (%d Kb) from field <strong>%s</strong> to <strong>%s</strong> as <strong>%s</strong>'
+      , req.files.image.originalFilename
+      , req.files.image.size / 1024 | 0
+      , req.files.image.fieldName
+      , req.files.image.path
+      , req.body.title));
+
+    // Do anything you want with your file...
+
+  } else {
+    res.send(format('\nform posted with value <strong>%s</strong>'
+      , req.body.title));
+  }
+});
+
+if (!module.parent) {
+  app.listen(3000);
+  console.log('Connect started on port 3000');
+}

--- a/index.js
+++ b/index.js
@@ -11,7 +11,8 @@
  */
 
 var multiparty = require('multiparty')
-  , qs = require('qs');
+  , qs = require('qs')
+  , fs = require('fs');
 
 /**
  * Multipart:
@@ -33,8 +34,9 @@ var multiparty = require('multiparty')
  * @api public
  */
 
-exports = module.exports = function(options){
+exports = module.exports = function(options, autoClean){
   options = options || {};
+  autoClean = autoClean || false;
 
   return function multipart(req, res, next) {
     if (req._body) return next();
@@ -76,6 +78,14 @@ exports = module.exports = function(options){
       val.name = val.originalFilename;
       val.type = val.headers['content-type'] || null;
       ondata(name, val, files);
+      if (autoClean) {
+        res.on('finish', function () {
+          fs.unlink(val.path, function (e) {
+            if (e)
+              console.log('connect-multiparty autoclean error: ' + e);
+          });
+        });
+      }
     });
 
     form.on('error', function(err){

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ var multiparty = require('multiparty')
 
 /**
  * Multipart:
- * 
+ *
  * Parse multipart/form-data request bodies,
  * providing the parsed object as `req.body`
  * and `req.files`.
@@ -25,11 +25,17 @@ var multiparty = require('multiparty')
  *
  *  The options passed are merged with [multiparty](https://github.com/andrewrk/node-multiparty)'s
  *  `Form` object, allowing you to configure the upload directory,
- *  size limits, etc. For example if you wish to change the upload dir do the following.
+ *  size limits, etc. For examples if you wish to change the upload dir do the following.
  *
  *     app.use(connect.multipart({ uploadDir: path }));
  *
+ * Pass an additionnal boolean to automatically remove temp files.
+ *
+ *     app.use(connect.multipart({ uploadDir: path }, true));
+ *     app.use(connect.multipart({}, true));
+ *
  * @param {Object} options
+ * @param boolean autoClean
  * @return {Function}
  * @api public
  */
@@ -79,12 +85,14 @@ exports = module.exports = function(options, autoClean){
       val.type = val.headers['content-type'] || null;
       ondata(name, val, files);
       if (autoClean) {
-        res.on('finish', function () {
+        var autoCleaner = function () {
           fs.unlink(val.path, function (e) {
             if (e)
               console.log('connect-multiparty autoclean error: ' + e);
           });
-        });
+        }
+        res.on('finish', autoCleaner);
+        res.on('close', autoCleaner);
       }
     });
 
@@ -104,7 +112,7 @@ exports = module.exports = function(options, autoClean){
         form.emit('error', err);
       }
     });
-    
+
     form.parse(req);
   }
 };

--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
   "devDependencies": {
     "mocha": "~1.13.0",
     "should": "~2.0.2",
-    "connect": "~2.9.2"
+    "connect": "~2.9.2",
+    "express": "~4.0.0",
+    "body-parser": "~1.0.2"
   },
   "bugs": {
     "url": "https://github.com/andrewrk/connect-multiparty/issues"


### PR DESCRIPTION
Add a second option to "multipart({}, true);" to trigger automatic temp files deletion.

It's a proposition and maybe the implementation is not totally compliant with Connect/Node standards.

I also wasn't able to run the repo tests (Uncaught Error: connect EADDRNOTAVAIL).